### PR TITLE
Add a new payments module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,3 +18,4 @@ export { default as Taxonomies } from './taxonomies';
 
 export { default as Users } from './users';
 
+export { default as Payments } from './payments';

--- a/src/payments/__tests__/_fixtures.js
+++ b/src/payments/__tests__/_fixtures.js
@@ -1,0 +1,56 @@
+export const success = {
+  "data": {
+    "entities": {
+      "invoices": {
+        "27336": {
+          "id":27336,
+          "uid":"2017_04_14_002",
+          "organisation_id":164,
+          "organisation_uid":"WAYSSJOBS",
+          "organisation_name":"WAYSS Ltd",
+          "service_name":"One job ad credit",
+          "service_description":"Added Value Job Ad Credits",
+          "quantity":1,
+          "download_url":"http:\/\/api.ethicaljobs.com.au\/organisation\/164\/invoice\/27336",
+          "amount":130,
+          "total":143,
+          "payment_method":"invoice",
+          "created_at":1492122937000,
+          "paid_at":1492122937000,
+        },
+      },
+    },
+    "result": 27336,
+  }
+};
+
+export const single = {
+  "data": {
+    "entities": {
+      "invoices": {
+        "27336": {
+          "id":27336,
+          "uid":"2017_04_14_002",
+          "organisation_id":164,
+          "organisation_uid":"WAYSSJOBS",
+          "organisation_name":"WAYSS Ltd",
+          "service_name":"One job ad credit",
+          "service_description":"Added Value Job Ad Credits",
+          "quantity":1,
+          "download_url":"http:\/\/api.ethicaljobs.com.au\/organisation\/164\/invoice\/27336",
+          "amount":130,
+          "total":143,
+          "payment_method":"invoice",
+          "created_at":1492122937000,
+          "paid_at":null
+        },
+      },
+    },
+    "result": 27336,
+  }
+};
+
+export const error = new Error('There was some kind of error', {
+  message: 'There was some kind of error',
+  statusCode: 500,
+});

--- a/src/payments/__tests__/actions.spec.js
+++ b/src/payments/__tests__/actions.spec.js
@@ -1,0 +1,11 @@
+import Payments from 'payments';
+const { actions } = Payments;
+
+const params = { foo: 'bar', bar: 'foo' };
+
+test('purchase creates correct action', () => {
+  expect(actions.purchase(params)).toEqual({
+    type: actions.PURCHASE,
+    payload: new Promise(() => {}),
+  });
+});

--- a/src/payments/__tests__/reducer.spec.js
+++ b/src/payments/__tests__/reducer.spec.js
@@ -1,0 +1,59 @@
+import Immutable from 'immutable';
+import { REQUEST, SUCCESS, FAILURE, Assertions } from 'ethical-jobs-redux';
+import { initialState } from 'payments/reducer';
+import * as Fixtures from './_fixtures';
+import Payments from 'payments';
+
+const Reducer = Payments.reducer;
+const Actions = Payments.actions;
+
+/*
+|--------------------------------------------------------------------------
+| Initial state
+|--------------------------------------------------------------------------
+*/
+
+test('should return correct initial state ', () => {
+  const expectedState = Immutable.fromJS({
+    fetching: false,
+    error: false,
+    filters: {},
+    entities: {},
+    results: [],
+    result: false,
+  });
+  expect(Assertions.initialState(Reducer, expectedState)).toBe(true);
+});
+
+/*
+|--------------------------------------------------------------------------
+| REQUEST actions
+|--------------------------------------------------------------------------
+*/
+
+test('should handle REQUEST actions correctly', () => {
+  const actionTypes = [
+    REQUEST(Actions.PURCHASE),
+  ];
+  expect(
+    Assertions.requestState(Reducer, actionTypes, initialState)
+  ).toBe(true);
+});
+
+test('should handle SUCCESS actions correctly', () => {
+  const actionTypes = [
+    SUCCESS(Actions.PURCHASE),
+  ];
+  expect(
+    Assertions.successState(Reducer, actionTypes, initialState, Fixtures.success)
+  ).toBe(true);
+});
+
+test('should handle FAILURE actions correctly', () => {
+  const actionTypes = [
+    FAILURE(Actions.PURCHASE),
+  ];
+  expect(
+    Assertions.failureState(Reducer, actionTypes, initialState, Fixtures.error)
+  ).toBe(true);
+});

--- a/src/payments/__tests__/selectors.spec.js
+++ b/src/payments/__tests__/selectors.spec.js
@@ -1,0 +1,12 @@
+import Immutable from 'immutable';
+import { Assertions } from 'ethical-jobs-redux';
+import Payments from 'payments';
+
+const { selectors } = Payments;
+
+test('fetching returns correct state slice ', () => {
+  expect(
+    Assertions.fetchingSelector('payments', selectors.fetching)
+  ).toBe(true);
+});
+

--- a/src/payments/actions.js
+++ b/src/payments/actions.js
@@ -1,0 +1,20 @@
+import { createActionType } from 'ethical-jobs-redux';
+import Api from 'ethical-jobs-sdk';
+
+/*
+|--------------------------------------------------------------------------
+| Action Types
+|--------------------------------------------------------------------------
+*/
+
+export const PURCHASE = createActionType('PAYMENTS/PURCHASE');
+
+/*
+|--------------------------------------------------------------------------
+| Async Actions
+|--------------------------------------------------------------------------
+*/
+export const purchase = params => ({
+  type: PURCHASE,
+  payload: Api.post('/payments', params),
+});

--- a/src/payments/index.js
+++ b/src/payments/index.js
@@ -1,0 +1,9 @@
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+export default {
+  reducer,
+  actions,
+  selectors,
+};

--- a/src/payments/reducer.js
+++ b/src/payments/reducer.js
@@ -1,0 +1,35 @@
+import Immutable from 'immutable';
+import { ImmutableUtils, REQUEST, SUCCESS, FAILURE } from 'ethical-jobs-redux';
+import * as PaymentActions from './actions';
+
+// Initial state
+export const initialState = Immutable.fromJS({
+  fetching: false,
+  error: false,
+  filters: {},
+  entities: {},
+  results: [],
+  result: false,
+});
+
+/**
+ * Purchase reducer
+ *
+ * @author Andrew McLagan <andrew@ethicaljobs.com.au>
+ */
+
+export default function reducer(state = initialState, action = {}) {
+  switch (action.type) {
+    case REQUEST(PaymentActions.PURCHASE):
+      return ImmutableUtils.mergeRequest(state);
+
+    case SUCCESS(PaymentActions.PURCHASE):
+      return ImmutableUtils.mergeSuccess(state, action.payload);
+
+    case FAILURE(PaymentActions.PURCHASE):
+      return ImmutableUtils.mergeFailure(state, action.payload);
+
+    default:
+      return state;
+  }
+}

--- a/src/payments/selectors.js
+++ b/src/payments/selectors.js
@@ -1,0 +1,5 @@
+import { SelectorFactory } from 'ethical-jobs-redux';
+
+export const fetching = SelectorFactory.create('payments', 'fetching');
+
+export const error = SelectorFactory.create('payments', 'error');


### PR DESCRIPTION
I've decided to make Payments a first class citizen of our API and redux modules. Currently payments are tracked against an Invoice and stored in the database on the invoices table but looking forward I think it would make sense for them to be their own conceptual entity. For example to support things like making multiple payments per invoice or payments against a user or organisation (subscription).