### PR TITLE
Feature/polyfill es6 features for ios8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babelrc-rollup": "^3.0.0",
+    "core.js": "^0.4.2",
     "globby": "^6.1.0",
     "gulp": "^3.9.1",
     "gulp-watch": "^4.3.11",

--- a/src/jobs/getFiltersByType.js
+++ b/src/jobs/getFiltersByType.js
@@ -1,3 +1,4 @@
+import 'core-js/fn/object/assign';
 import JobStatus from './statuses';
 
 const JobTypes = Object.assign({}, JobStatus, {

--- a/src/taxonomies/selectors.js
+++ b/src/taxonomies/selectors.js
@@ -1,3 +1,5 @@
+import 'core-js/fn/number/is-integer';
+
 import Immutable from 'immutable';
 import { SelectorFactory } from 'ethical-jobs-redux';
 import { createSelector } from 'reselect';


### PR DESCRIPTION
Use Core.js to polyfill ES6 features like Number.IsInteger and Object.Assign for older browsers. 