### PR TITLE
 Feature/subscriptions module

### DIFF
--- a/src/subscriptions/__tests__/_fixtures.js
+++ b/src/subscriptions/__tests__/_fixtures.js
@@ -1,0 +1,81 @@
+export const success = {
+  "data": {
+    "entities": {
+      "alerts": {
+        "14": {
+          "id": 14,
+          "frequency": "daily",
+          "keyword": "communications",
+          "categories": 42,
+          "locations": 11,
+          "workTypes": null,
+          "created_at": 1512435775000,
+          "updated_at": 1512435775000
+        },
+        "18": {
+          "id": 18,
+          "frequency": "daily",
+          "keyword": "counsellor",
+          "categories": 38,
+          "locations": 15,
+          "workTypes": null,
+          "created_at": 1512435775000,
+          "updated_at": 1512435775000
+        }
+      },
+      "subscriptions": {
+        "34": {
+          "id": 34,
+          "alert_id": 14,
+          "email": "schroeder.griffin@yahoo.com",
+          "created_at": 1512435847000
+        },
+        "41": {
+          "id": 41,
+          "alert_id": 18,
+          "email": "schroeder.griffin@yahoo.com",
+          "created_at": 1512435847000
+        }
+      }
+    },
+    "result": [
+      34,
+      41
+    ]
+  }
+}
+
+export const single = {
+  "data": {
+    "entities": {
+      "alerts": {
+        "15": {
+          "id": 15,
+          "frequency": "daily",
+          "keyword": null,
+          "categories": 16,
+          "locations": null,
+          "workTypes": 3,
+          "created_at": 1512435775000,
+          "updated_at": 1512435775000
+        }
+      },
+      "subscriptions": {
+        "3": {
+          "id": 3,
+          "alert_id": 15,
+          "email": "felix.muller@feest.com",
+          "created_at": 1512435847000
+        }
+      }
+    },
+    "result": [
+      3
+    ]
+  }
+}
+
+export const error = new Error('There was some kind of error', {
+  message: 'There was some kind of error',
+  statusCode: 500,
+});

--- a/src/subscriptions/__tests__/actions.spec.js
+++ b/src/subscriptions/__tests__/actions.spec.js
@@ -1,0 +1,40 @@
+import Subscriptions from 'subscriptions';
+const { actions } = Subscriptions;
+
+const params = { foo: 'bar', bar: 'foo' };
+
+test('create creates correct action', () => {
+  expect(actions.create(params)).toEqual({
+    type: actions.CREATE,
+    payload: new Promise(() => {}),
+  });
+});
+
+test('fetchCollection creates correct action', () => {
+  expect(actions.fetchCollection(params)).toEqual({
+    type: actions.FETCH_COLLECTION,
+    payload: new Promise(() => {}),
+  });
+});
+
+
+test('fetchEntity creates correct action', () => {
+  expect(actions.fetchEntity(params)).toEqual({
+    type: actions.FETCH_ENTITY,
+    payload: new Promise(() => {}),
+  });
+});
+
+test('destroy creates correct action', () => {
+  expect(actions.destroy(params)).toEqual({
+    type: actions.DELETE,
+    payload: new Promise(() => {}),
+  });
+});
+
+test('update creates correct action', () => {
+  expect(actions.update(params)).toEqual({
+    type: actions.CONFIRM,
+    payload: new Promise(() => {}),
+  });
+});

--- a/src/subscriptions/__tests__/reducer.spec.js
+++ b/src/subscriptions/__tests__/reducer.spec.js
@@ -1,0 +1,70 @@
+import Immutable from 'immutable';
+import { REQUEST, SUCCESS, FAILURE, Assertions } from 'ethical-jobs-redux';
+import { initialState } from 'subscriptions/reducer';
+import * as Fixtures from './_fixtures';
+import Subscriptions from 'subscriptions';
+
+const Reducer = Subscriptions.reducer;
+const Actions = Subscriptions.actions;
+
+/*
+|--------------------------------------------------------------------------
+| Initial state
+|--------------------------------------------------------------------------
+*/
+
+test('should return correct initial state ', () => {
+  const expectedState = Immutable.fromJS({
+    fetching: false,
+    error: false,
+    filters: {},
+    entities: {},
+    results: [],
+    result: false,
+  });
+  expect(Assertions.initialState(Reducer, expectedState)).toBe(true);
+});
+
+/*
+|--------------------------------------------------------------------------
+| REQUEST actions
+|--------------------------------------------------------------------------
+*/
+
+test('should handle REQUEST actions correctly', () => {
+  const actionTypes = [
+    REQUEST(Actions.CREATE),
+    REQUEST(Actions.FETCH_COLLECTION),
+    REQUEST(Actions.FETCH_ENTITY),
+    REQUEST(Actions.DELETE),
+    REQUEST(Actions.CONFIRM),
+  ];
+  expect(
+    Assertions.requestState(Reducer, actionTypes, initialState)
+  ).toBe(true);
+});
+
+test('should handle SUCCESS actions correctly', () => {
+  const actionTypes = [
+    SUCCESS(Actions.CREATE),
+    SUCCESS(Actions.FETCH_ENTITY),
+    SUCCESS(Actions.DELETE),
+    SUCCESS(Actions.CONFIRM),
+  ];
+  expect(
+    Assertions.successState(Reducer, actionTypes, initialState, Fixtures.success)
+  ).toBe(true);
+});
+
+test('should handle FAILURE actions correctly', () => {
+  const actionTypes = [
+    FAILURE(Actions.CREATE),
+    FAILURE(Actions.FETCH_COLLECTION),
+    FAILURE(Actions.FETCH_ENTITY),
+    FAILURE(Actions.DELETE),
+    FAILURE(Actions.CONFIRM),
+  ];
+  expect(
+    Assertions.failureState(Reducer, actionTypes, initialState, Fixtures.error)
+  ).toBe(true);
+});

--- a/src/subscriptions/__tests__/selectors.spec.js
+++ b/src/subscriptions/__tests__/selectors.spec.js
@@ -1,0 +1,29 @@
+import Immutable from 'immutable';
+import { Assertions } from 'ethical-jobs-redux';
+import Subscriptions from 'subscriptions';
+
+const { selectors } = Subscriptions;
+
+test('fetching returns correct state slice', () => {
+  expect(
+    Assertions.fetchingSelector('subscriptions', selectors.fetching)
+  ).toBe(true);
+});
+
+test('result selector returns correct state slice', () => {
+  expect(
+    Assertions.resultSelector('subscriptions', selectors.result)
+  ).toBe(true);
+});
+
+test('subscriptions selector returns correct state slice', () => {
+  expect(
+    Assertions.entitiesSelector('subscriptions', 'subscriptions', selectors.subscriptions)
+  ).toBe(true);
+});
+
+test('alerts selector returns correct state slice', () => {
+  expect(
+    Assertions.entitiesSelector('subscriptions', 'alerts', selectors.alerts)
+  ).toBe(true);
+});

--- a/src/subscriptions/actions.js
+++ b/src/subscriptions/actions.js
@@ -1,0 +1,44 @@
+import { createActionType } from 'ethical-jobs-redux';
+import Api from 'ethical-jobs-sdk';
+
+/*
+|--------------------------------------------------------------------------
+| Action Types
+|--------------------------------------------------------------------------
+*/
+
+export const CREATE = createActionType('SUBSCRIPTIONS/CREATE');
+export const FETCH_COLLECTION = createActionType('SUBSCRIPTIONS/FETCH_COLLECTION');
+export const FETCH_ENTITY = createActionType('SUBSCRIPTIONS/FETCH_ENTITY');
+export const DELETE = createActionType('SUBSCRIPTIONS/DELETE');
+export const CONFIRM = createActionType('SUBSCRIPTIONS/CONFIRM');
+
+/*
+|--------------------------------------------------------------------------
+| Async Actions
+|--------------------------------------------------------------------------
+*/
+export const create = params => ({
+  type: CREATE,
+  payload: Api.post('/email/subscriptions', params),
+});
+
+export const fetchCollection = params => ({
+  type: FETCH_COLLECTION,
+  payload: Api.get('/email/subscriptions', params),
+});
+
+export const fetchEntity = id => ({
+  type: FETCH_ENTITY,
+  payload: Api.get(`/email/subscriptions/${id}`),
+});
+
+export const destroy = id => ({
+  type: DELETE,
+  payload: Api.delete(`/email/subscriptions/${id}`),
+});
+
+export const update = (id) => ({
+  type: CONFIRM,
+  payload: Api.get(`/email/subscriptions/${id}/confirmations`),
+});

--- a/src/subscriptions/index.js
+++ b/src/subscriptions/index.js
@@ -1,0 +1,9 @@
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+export default {
+  reducer,
+  actions,
+  selectors,
+};

--- a/src/subscriptions/reducer.js
+++ b/src/subscriptions/reducer.js
@@ -1,0 +1,50 @@
+import Immutable from 'immutable';
+import { ImmutableUtils, REQUEST, SUCCESS, FAILURE } from 'ethical-jobs-redux';
+import * as Subscriptions from './actions';
+
+// Initial state
+export const initialState = Immutable.fromJS({
+  fetching: false,
+  error: false,
+  filters: {},
+  entities: {},
+  results: [],
+  result: false,
+});
+
+/**
+ * subscriptions reducer
+ *
+ * @author Sebastian Sibelle <sebastian@ethicaljobs.com.au>
+ */
+
+export default function reducer(state = initialState, action = {}) {
+  switch (action.type) {
+
+    case REQUEST(Subscriptions.CREATE):
+    case REQUEST(Subscriptions.FETCH_COLLECTION):
+    case REQUEST(Subscriptions.FETCH_ENTITY):
+    case REQUEST(Subscriptions.DELETE):
+    case REQUEST(Subscriptions.CONFIRM):
+      return ImmutableUtils.mergeRequest(state);
+
+    case SUCCESS(Subscriptions.CREATE):
+    case SUCCESS(Subscriptions.FETCH_ENTITY):
+    case SUCCESS(Subscriptions.DELETE):
+    case SUCCESS(Subscriptions.CONFIRM):
+      return ImmutableUtils.mergeSuccess(state, action.payload);
+
+    case SUCCESS(Subscriptions.FETCH_COLLECTION):
+      return ImmutableUtils.mergeCollectionSuccess(state, action.payload);
+
+    case FAILURE(Subscriptions.CREATE):
+    case FAILURE(Subscriptions.FETCH_ENTITY):
+    case FAILURE(Subscriptions.FETCH_COLLECTION):
+    case FAILURE(Subscriptions.DELETE):
+    case FAILURE(Subscriptions.CONFIRM):
+      return ImmutableUtils.mergeFailure(state, action.payload);
+
+    default:
+      return state;
+  }
+}

--- a/src/subscriptions/selectors.js
+++ b/src/subscriptions/selectors.js
@@ -1,0 +1,13 @@
+import { SelectorFactory } from 'ethical-jobs-redux';
+
+export const fetching = SelectorFactory.create('subscriptions', 'fetching');
+
+export const error = SelectorFactory.create('subscriptions', 'error');
+
+export const result = SelectorFactory.createResultSelector('subscriptions');
+
+export const results = SelectorFactory.createResultsSelector('subscriptions');
+
+export const subscriptions = SelectorFactory.createEntitiesSelector('subscriptions');
+
+export const alerts = SelectorFactory.createEntitiesSelector('subscriptions','alerts');


### PR DESCRIPTION
Adding a subscriptions module to the redux module.

It includes actions to create, destroy, confirm and fetch subscriptions. 

Including tests and pretty standard formatting. I'm not 100% sure on the selectors we may need to add a few more down the line but it's a good start. 